### PR TITLE
Make usage of cron intervals optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,16 @@ CronProps {
    * Default: false
    */
   humanizeValue?: boolean
+  
+  /**
+   * Controls whether to use cron intervals syntax.
+   *
+   * Example: When set to true, a cron expression like '0 8 * * 1,3,5' ("At 08:00 AM, only on Monday, Wednesday, and Friday")
+   * would be changed to '0 8 * * 1-5/2' ("At 08:00 AM, every 2 days of the week, Monday through Friday")
+   *
+   * Default: true
+   */
+  useCronIntervals?: boolean
 
   /**
    * Add a "0" before numbers lower than 10.

--- a/src/Cron.tsx
+++ b/src/Cron.tsx
@@ -28,6 +28,7 @@ export default function Cron(props: CronProps) {
     allowEmpty = 'for-default-value',
     humanizeLabels = true,
     humanizeValue = false,
+    useCronIntervals = true,
     disabled = false,
     readOnly = false,
     leadingZero = false,
@@ -126,7 +127,8 @@ export default function Cron(props: CronProps) {
           weekDays,
           hours,
           minutes,
-          humanizeValue
+          humanizeValue,
+          useCronIntervals,
         )
 
         setValue(cron)
@@ -147,6 +149,7 @@ export default function Cron(props: CronProps) {
       hours,
       minutes,
       humanizeValue,
+      useCronIntervals,
       valueCleared,
     ]
   )
@@ -290,6 +293,7 @@ export default function Cron(props: CronProps) {
                 disabled={disabled}
                 readOnly={readOnly}
                 period={periodForRender}
+                useCronIntervals={useCronIntervals}
                 {...selectProps}
               />
             )}
@@ -305,6 +309,7 @@ export default function Cron(props: CronProps) {
                 readOnly={readOnly}
                 leadingZero={leadingZero}
                 period={periodForRender}
+                useCronIntervals={useCronIntervals}
                 {...selectProps}
               />
             )}
@@ -322,6 +327,7 @@ export default function Cron(props: CronProps) {
                   disabled={disabled}
                   readOnly={readOnly}
                   period={periodForRender}
+                  useCronIntervals={useCronIntervals}
                   {...selectProps}
                 />
               )}
@@ -338,6 +344,7 @@ export default function Cron(props: CronProps) {
                   leadingZero={leadingZero}
                   clockFormat={clockFormat}
                   period={periodForRender}
+                  useCronIntervals={useCronIntervals}
                   {...selectProps}
                 />
               )}
@@ -353,6 +360,7 @@ export default function Cron(props: CronProps) {
                   readOnly={readOnly}
                   leadingZero={leadingZero}
                   clockFormat={clockFormat}
+                  useCronIntervals={useCronIntervals}
                   {...selectProps}
                 />
               )}

--- a/src/components/CustomSelect.tsx
+++ b/src/components/CustomSelect.tsx
@@ -13,13 +13,14 @@ export default function CustomSelect(props: CustomSelectProps) {
     locale,
     className,
     humanizeLabels,
+    useCronIntervals,
     disabled,
     readOnly,
     leadingZero,
     clockFormat,
     optionsList,
     unit,
-    ...selectProps,
+    ...selectProps
   } = props
 
   const stringValue = useMemo(() => {
@@ -65,7 +66,7 @@ export default function CustomSelect(props: CustomSelectProps) {
     (props) => {
       const value = props
 
-      if (!value || Number(value[0]) === NaN) {
+      if (!value || isNaN(Number(value[0]))) {
         return <></>
       }
 
@@ -74,6 +75,7 @@ export default function CustomSelect(props: CustomSelectProps) {
         parsedArray,
         unit,
         humanizeLabels,
+        useCronIntervals,
         leadingZero,
         clockFormat
       )

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -106,7 +106,8 @@ export function getCronStringFromValues(
   weekDays: number[] | undefined,
   hours: number[] | undefined,
   minutes: number[] | undefined,
-  humanizeValue?: boolean
+  humanizeValue?: boolean,
+  useCronIntervals?: boolean,
 ) {
   if (period === 'reboot') {
     return '@reboot'
@@ -125,7 +126,8 @@ export function getCronStringFromValues(
 
   const parsedArray = parseCronArray(
     [newMinutes, newHours, newMonthDays, newMonths, newWeekDays],
-    humanizeValue
+    humanizeValue,
+    useCronIntervals,
   )
 
   return cronToString(parsedArray)
@@ -138,6 +140,7 @@ export function partToString(
   cronPart: number[],
   unit: Unit,
   humanize?: boolean,
+  useCronIntervals?: boolean,
   leadingZero?: LeadingZero,
   clockFormat?: ClockFormat
 ) {
@@ -148,7 +151,7 @@ export function partToString(
   } else {
     const step = getStep(cronPart)
 
-    if (step && isInterval(cronPart, step)) {
+    if (useCronIntervals && step && isInterval(cronPart, step)) {
       if (isFullInterval(cronPart, unit, step)) {
         retval = `*/${step}`
       } else {
@@ -233,13 +236,13 @@ export function formatValue(
 /**
  * Parses a 2-dimentional array of integers as a cron schedule
  */
-function parseCronArray(cronArr: number[][], humanizeValue?: boolean) {
+function parseCronArray(cronArr: number[][], humanizeValue?: boolean, useCronIntervals?: boolean) {
   if (cronArr.length === 5) {
     return cronArr.map((partArr, idx) => {
       const unit = UNITS[idx]
       const parsedArray = parsePartArray(partArr, unit)
 
-      return partToString(parsedArray, unit, humanizeValue)
+      return partToString(parsedArray, unit, humanizeValue, useCronIntervals)
     })
   }
 

--- a/src/stories/index.stories.tsx
+++ b/src/stories/index.stories.tsx
@@ -95,6 +95,7 @@ export function DynamicSettings() {
   const [readOnly, setReadOnly] = useState<boolean>(false)
   const [humanizeLabels, setHumanizeLabels] = useState<boolean>(true)
   const [humanizeValue, setHumanizeValue] = useState<boolean>(false)
+  const [useCronIntervals, setUseCronIntervals] = useState<boolean>(true)
   const [displayErrorText, setDisplayErrorText] = useState<boolean>(true)
   const [displayErrorStyle, setDisplayErrorStyle] = useState<boolean>(true)
   const [displayClearButton, setDisplayClearButton] = useState<boolean>(true)
@@ -201,7 +202,7 @@ export function DynamicSettings() {
             onChange={() => setReadOnly((prevValue) => !prevValue)}
           />
         } />
-        <FormControlLabel label='Humainze labels' control={
+        <FormControlLabel label='Humanize labels' control={
           <Switch
             checked={humanizeLabels}
             onChange={() => setHumanizeLabels((prevValue) => !prevValue)}
@@ -211,6 +212,12 @@ export function DynamicSettings() {
           <Switch
             checked={humanizeValue}
             onChange={() => setHumanizeValue((prevValue) => !prevValue)}
+          />
+        } />
+        <FormControlLabel label='Use cron intervals' control={
+          <Switch
+            checked={useCronIntervals}
+            onChange={() => setUseCronIntervals((prevValue) => !prevValue)}
           />
         } />
         <FormControlLabel label='Display error text' control={
@@ -358,6 +365,7 @@ export function DynamicSettings() {
         readOnly={readOnly}
         humanizeLabels={humanizeLabels}
         humanizeValue={humanizeValue}
+        useCronIntervals={useCronIntervals}
         displayError={displayErrorStyle}
         clearButton={displayClearButton}
         clearButtonAction={clearButtonAction}

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,16 @@ export interface CronProps {
   humanizeValue?: boolean
 
   /**
+   * Controls whether to use cron intervals syntax.
+   *
+   * Example: When set to true, a cron expression like '0 8 * * 1,3,5' ("At 08:00 AM, only on Monday, Wednesday, and Friday")
+   * would be changed to '0 8 * * 1-5/2' ("At 08:00 AM, every 2 days of the week, Monday through Friday")
+   *
+   * Default: true
+   */
+  useCronIntervals?: boolean
+
+  /**
    * Add a "0" before numbers lower than 10.
    *
    * Default: false
@@ -218,10 +228,11 @@ export interface FieldProps {
   className?: string
   disabled: boolean
   readOnly: boolean
+  useCronIntervals: boolean
   period: PeriodType
 }
 export interface PeriodProps
-  extends Omit<FieldProps, 'value' | 'setValue' | 'period'> {
+  extends Omit<FieldProps, 'value' | 'setValue' | 'period' | 'useCronIntervals'> {
   value: PeriodType
   setValue: SetValuePeriod
   shortcuts: Shortcuts
@@ -270,6 +281,7 @@ export interface CustomSelectProps
   locale: Locale
   value?: number[]
   humanizeLabels?: boolean
+  useCronIntervals?: boolean
   disabled: boolean
   readOnly: boolean
   leadingZero?: LeadingZero


### PR DESCRIPTION
<!--
Thank you for your contribution! 😄
-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] README update
- [ ] Other (about what?)

### 🔗 Related issue link

Don't have one.

### 💡 Background and solution

The default implementation is to use cron intervals when defining a period with a repetitive pattern with a fixed step.

For instance, if you select `8AM on Monday, Wednesday and Friday`, the current implementation will give you only this cron expression `'0 8 * * 1-5/2'` (which means "At 08:00 AM, every 2 days of the week, Monday through Friday") instead of `'0 8 * * 1,3,5'` ("At 08:00 AM, only on Monday, Wednesday, and Friday").

This is semantically equal, but in some contexts the more explicit expression is preferred (or needed, because some libraries don't work well with cron intervals).

So this PR proposes to add a new optional boolean prop `useCronIntervals` to control whether to use cron intervals or not, so it can be configured by the client.
  
<!--
- Describe the problem and the scenario
- Describe the solution
- Describe the final API implementation
-->

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Demo in storybook is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] README API section is updated or not needed
