### PR TITLE
Add periodsToDisplay and allowMultipleSelectFor optional configuration fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,31 @@ CronProps {
    * Default: 'day'
    */
   defaultPeriod?: 'year' | 'month' | 'week' | 'day' | 'hour' | 'minute' | 'reboot'
+  
+  /**
+   * Define the options of periods that will be displayed.
+   *
+   * Example: If you only want the option to generate cron expressions to
+   * represent a time in the day you can define periodsToDisplay={['day']}.
+   * The other options won't be available in the period select component.
+   *
+   * Default: ['year', 'month', 'week', 'day', 'hour', 'minute', 'reboot']
+   *
+   * OBS: 'reboot' option will apply only when '@reboot' is listed in shortcuts list.
+   */
+  periodsToDisplay?: ('year' | 'month' | 'week' | 'day' | 'hour' | 'minute' | 'reboot')[]
+
+  /**
+   * Define which fields can select multiple values.
+   *
+   * Example: If you don't want to allow multiple hours or minutes to be selected,
+   * you can define allowMultipleSelectFor={['months', 'month-days', 'week-days']}.
+   * This way only months, month days and week days select components will be allowed
+   * to have multiple values in the cron expression.
+   *
+   * Default: ['months', 'month-days', 'week-days', 'hours', 'minutes']
+   */
+  allowMultipleSelectFor?: ('months' | 'month-days' | 'week-days' | 'hours' | 'minutes')[]
 
   /**
    * Disable the cron component.

--- a/src/Cron.tsx
+++ b/src/Cron.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useEffect, useRef, useMemo } from 'react'
 import { Button } from '@material-ui/core'
 import { CronProps, PeriodType } from './types'
-import Period from './fields/Period'
+import Period, { ALL_PERIODS } from './fields/Period'
 import MonthDays from './fields/MonthDays'
 import Months from './fields/Months'
 import Hours from './fields/Hours'
@@ -25,6 +25,7 @@ export default function Cron(props: CronProps) {
     onError,
     className,
     defaultPeriod = 'day',
+    periodsToDisplay = ALL_PERIODS,
     allowEmpty = 'for-default-value',
     humanizeLabels = true,
     humanizeValue = false,
@@ -276,6 +277,7 @@ export default function Cron(props: CronProps) {
         disabled={disabled}
         readOnly={readOnly}
         shortcuts={shortcuts}
+        periodsToDisplay={periodsToDisplay}
         {...selectProps}
       />
 

--- a/src/Cron.tsx
+++ b/src/Cron.tsx
@@ -26,6 +26,13 @@ export default function Cron(props: CronProps) {
     className,
     defaultPeriod = 'day',
     periodsToDisplay = ALL_PERIODS,
+    allowMultipleSelectFor = [
+      'months',
+      'month-days',
+      'week-days',
+      'hours',
+      'minutes',
+    ],
     allowEmpty = 'for-default-value',
     humanizeLabels = true,
     humanizeValue = false,
@@ -296,6 +303,7 @@ export default function Cron(props: CronProps) {
                 readOnly={readOnly}
                 period={periodForRender}
                 useCronIntervals={useCronIntervals}
+                multiple={allowMultipleSelectFor.includes('months')}
                 {...selectProps}
               />
             )}
@@ -312,6 +320,7 @@ export default function Cron(props: CronProps) {
                 leadingZero={leadingZero}
                 period={periodForRender}
                 useCronIntervals={useCronIntervals}
+                multiple={allowMultipleSelectFor.includes('month-days')}
                 {...selectProps}
               />
             )}
@@ -330,6 +339,7 @@ export default function Cron(props: CronProps) {
                   readOnly={readOnly}
                   period={periodForRender}
                   useCronIntervals={useCronIntervals}
+                  multiple={allowMultipleSelectFor.includes('week-days')}
                   {...selectProps}
                 />
               )}
@@ -347,6 +357,7 @@ export default function Cron(props: CronProps) {
                   clockFormat={clockFormat}
                   period={periodForRender}
                   useCronIntervals={useCronIntervals}
+                  multiple={allowMultipleSelectFor.includes('hours')}
                   {...selectProps}
                 />
               )}
@@ -363,6 +374,7 @@ export default function Cron(props: CronProps) {
                   leadingZero={leadingZero}
                   clockFormat={clockFormat}
                   useCronIntervals={useCronIntervals}
+                  multiple={allowMultipleSelectFor.includes('minutes')}
                   {...selectProps}
                 />
               )}

--- a/src/components/CustomSelect.tsx
+++ b/src/components/CustomSelect.tsx
@@ -21,6 +21,7 @@ export default function CustomSelect(props: CustomSelectProps) {
     optionsList,
     unit,
     multiple,
+    grid: _grid,
     ...selectProps
   } = props
 

--- a/src/components/CustomSelect.tsx
+++ b/src/components/CustomSelect.tsx
@@ -20,6 +20,7 @@ export default function CustomSelect(props: CustomSelectProps) {
     clockFormat,
     optionsList,
     unit,
+    multiple,
     ...selectProps
   } = props
 
@@ -97,13 +98,22 @@ export default function CustomSelect(props: CustomSelectProps) {
   const simpleClick = useCallback(
     (event: any) => {
       let newValueOption: number[] = event.target.value;
-      if (newValueOption.length == 0) {
-        newValueOption.push(0);
+      let newValue: number[];
+
+      if (Array.isArray(newValueOption)) {
+        if (newValueOption.length == 0) {
+          newValueOption.push(0);
+        }
+
+        if (newValueOption.length > 0 && !multiple) {
+          // Save only the last one selected in case it shouldn't allow multiple values
+          newValueOption = [newValueOption[newValueOption.length - 1]]
+        }
+
+        newValue = sort(newValueOption)
+      } else {
+        newValue = [newValueOption]
       }
-      newValueOption = Array.isArray(newValueOption)
-        ? sort(newValueOption)
-        : [newValueOption]
-      const newValue: number[] = newValueOption
 
       if (newValue.length === unit.total) {
         setValue([])

--- a/src/fields/Period.tsx
+++ b/src/fields/Period.tsx
@@ -1,9 +1,19 @@
 import React, { useCallback, useMemo } from 'react'
 import { Select, MenuItem } from '@material-ui/core'
 
-import { PeriodProps } from '../types'
+import { PeriodProps, PeriodType } from '../types'
 import { DEFAULT_LOCALE_EN } from '../locale'
 import { classNames } from '../utils'
+
+export const ALL_PERIODS = [
+  'year',
+  'month',
+  'week',
+  'day',
+  'hour',
+  'minute',
+  'reboot',
+] as PeriodType[]
 
 export default function Period(props: PeriodProps) {
   const {
@@ -14,44 +24,62 @@ export default function Period(props: PeriodProps) {
     disabled,
     readOnly,
     shortcuts,
+    periodsToDisplay = ALL_PERIODS,
     ...selectProps
   } = props
-  let options = [
-    {
-      value: 'year',
-      label: locale.yearOption || DEFAULT_LOCALE_EN.yearOption,
-    },
-    {
-      value: 'month',
-      label: locale.monthOption || DEFAULT_LOCALE_EN.monthOption,
-    },
-    {
-      value: 'week',
-      label: locale.weekOption || DEFAULT_LOCALE_EN.weekOption,
-    },
-    {
-      value: 'day',
-      label: locale.dayOption || DEFAULT_LOCALE_EN.dayOption,
-    },
-    {
-      value: 'hour',
-      label: locale.hourOption || DEFAULT_LOCALE_EN.hourOption,
-    },
-    {
-      value: 'minute',
-      label: locale.minuteOption || DEFAULT_LOCALE_EN.minuteOption,
-    },
-  ]
 
-  if (shortcuts && (shortcuts === true || shortcuts.includes('@reboot'))) {
-    options = [
-      ...options,
+  const options = useMemo(() => {
+    const opts = [
       {
-        value: 'reboot',
-        label: locale.rebootOption || DEFAULT_LOCALE_EN.rebootOption,
+        value: 'year',
+        label: locale.yearOption || DEFAULT_LOCALE_EN.yearOption,
+      },
+      {
+        value: 'month',
+        label: locale.monthOption || DEFAULT_LOCALE_EN.monthOption,
+      },
+      {
+        value: 'week',
+        label: locale.weekOption || DEFAULT_LOCALE_EN.weekOption,
+      },
+      {
+        value: 'day',
+        label: locale.dayOption || DEFAULT_LOCALE_EN.dayOption,
+      },
+      {
+        value: 'hour',
+        label: locale.hourOption || DEFAULT_LOCALE_EN.hourOption,
+      },
+      {
+        value: 'minute',
+        label: locale.minuteOption || DEFAULT_LOCALE_EN.minuteOption,
       },
     ]
-  }
+
+    if (shortcuts && (shortcuts === true || shortcuts.includes('@reboot'))) {
+      opts.push({
+        value: 'reboot',
+        label: locale.rebootOption || DEFAULT_LOCALE_EN.rebootOption,
+      })
+    }
+
+    return opts
+  }, [
+    locale.yearOption,
+    locale.monthOption,
+    locale.weekOption,
+    locale.dayOption,
+    locale.hourOption,
+    locale.minuteOption,
+    locale.rebootOption,
+    shortcuts,
+  ])
+
+  const selectedPeriodOptions = useMemo(() => {
+    return options.filter(
+      option => periodsToDisplay.includes(option.value)
+    );
+  }, [options, periodsToDisplay])
 
   const handleChange = useCallback(
     (event) => {
@@ -110,7 +138,7 @@ export default function Period(props: PeriodProps) {
         open={readOnly ? false : undefined}
         {...selectProps}
       >
-        {options.map((obj) => (
+        {selectedPeriodOptions.map((obj) => (
           <MenuItem key={obj.value} value={obj.value}>
             {obj.label}
           </MenuItem>

--- a/src/stories/index.stories.tsx
+++ b/src/stories/index.stories.tsx
@@ -14,7 +14,13 @@ import {
   TableCell,
   TableBody,
   Typography,
-  TextFieldProps
+  TextFieldProps,
+  Select,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Checkbox,
+  ListItemText,
 } from '@material-ui/core'
 import InfoIcon from '@material-ui/icons/Info';
 import DividerWithText from '../components/DividerWithText'
@@ -28,6 +34,7 @@ import {
 import { ClearButtonAction } from '../types'
 
 import './styles.stories.css'
+import { ALL_PERIODS } from '../fields/Period'
 
 export default {
   title: 'ReactJS Cron',
@@ -527,6 +534,186 @@ export function DefaultPeriod() {
         <InfoIcon style={{ marginRight: 5 }} />
         <span style={{ fontSize: 12 }}>
           If not set, the prop &quot;defaultPeriod&quot; is &quot;day&quot;
+        </span>
+      </div>
+    </div>
+  )
+}
+
+export function PeriodsToDisplay() {
+  const defaultValue = ''
+  const [periodsToDisplay, setPeriodsToDisplay] = useState<string[]>(['week', 'day'])
+  const [value, setValue] = useState(defaultValue)
+  const [key, setKey] = useState('render-periods-to-display-example')
+
+  function resetCronComponent() {
+    setKey(Math.random().toString(36).substring(7))
+  }
+
+  return (
+    <div>
+      <div style={{ marginBottom: 30 }}>
+        <p>You can select only specific periods to be displayed in the dropdown to restrict the options.</p>
+      </div>
+
+      <div>
+        <FormControl style={{ minWidth: 250, maxWidth: 500 }}>
+          <InputLabel id="periods-to-display-label">Periods to Display</InputLabel>
+          <Select
+            labelId="periods-to-display-label"
+            id="periods-to-display"
+            multiple
+            value={periodsToDisplay}
+            onChange={event => {
+              let selectedPeriods = event.target.value as string[]
+
+              if (selectedPeriods.length === 0) {
+                // Leave 'day' as fallback if none is selected
+                selectedPeriods = ['day']
+              }
+
+              setPeriodsToDisplay(selectedPeriods)
+              setValue(defaultValue)
+              resetCronComponent()
+            }}
+            input={<Input />}
+            renderValue={(selected: string[]) => selected.join(', ')}
+          >
+            {ALL_PERIODS.map(period => (
+              <MenuItem key={period} value={period}>
+                <Checkbox checked={periodsToDisplay.indexOf(period) > -1} />
+                <ListItemText primary={period} />
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </div>
+
+      <p>Value: {value}</p>
+
+      <Cron
+        key={key}
+        value={value}
+        setValue={setValue}
+        clearButtonAction="empty"
+        periodsToDisplay={periodsToDisplay}
+      />
+
+      <div>
+        <InfoIcon style={{ marginRight: 5 }} />
+        <span style={{ fontSize: 12 }}>
+          If not set, the prop &quot;periodsToDisplay&quot; is {JSON.stringify(ALL_PERIODS)}
+          <span style={{ marginLeft: 5 }}>
+            <i>(&quot;reboot&quot; option will apply only when &quot;@reboot&quot; is listed in shortcuts list.)</i>
+          </span>
+        </span>
+      </div>
+    </div>
+  )
+}
+
+export function AllowMultipleSelectFor() {
+  const allFields = ['months', 'month-days', 'week-days', 'hours', 'minutes']
+  const defaultValue = ''
+  const [allowMultipleSelectFor, setAllowMultipleSelectFor] = useState(['months', 'month-days', 'week-days'])
+  const [value, setValue] = useState(defaultValue)
+  const [key, setKey] = useState('render-periods-to-display-example')
+
+  function resetCronComponent() {
+    setKey(Math.random().toString(36).substring(7))
+  }
+
+  return (
+    <div>
+      <div style={{ marginBottom: 30 }}>
+        <p>You can define specific fields in the component to accept multiple values.</p>
+      </div>
+
+      <div>
+        <FormControl style={{ minWidth: 250, maxWidth: 500 }}>
+          <InputLabel id="allow-multiple-select-for-label">Allow multiple select for</InputLabel>
+          <Select
+            labelId="allow-multiple-select-for-label"
+            id="allow-multiple-select-for"
+            multiple
+            value={allowMultipleSelectFor}
+            onChange={event => {
+              setAllowMultipleSelectFor(event.target.value as string[])
+              setValue(defaultValue)
+              resetCronComponent()
+            }}
+            input={<Input />}
+            renderValue={(selected: string[]) => selected.join(', ')}
+          >
+            {allFields.map(field => (
+              <MenuItem key={field} value={field}>
+                <Checkbox checked={allowMultipleSelectFor.indexOf(field) > -1} />
+                <ListItemText primary={field} />
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </div>
+
+      <p>Value: {value}</p>
+
+      <Cron
+        key={key}
+        leadingZero
+        value={value}
+        setValue={setValue}
+        clearButtonAction="empty"
+        allowMultipleSelectFor={allowMultipleSelectFor}
+      />
+
+      <div>
+        <InfoIcon style={{ marginRight: 5 }} />
+        <span style={{ fontSize: 12 }}>
+          If not set, the prop &quot;allowMultipleSelectFor&quot; is {JSON.stringify(allFields)}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+export function UseCronIntervals() {
+  const defaultValue = ' 0 8 * * 1,3,5'
+  const [value, setValue] = useState(defaultValue)
+  const [useCronIntervals, setUseCronIntervals] = useState(true)
+
+  return (
+    <div>
+      <div style={{ marginBottom: 30 }}>
+        <p>Controls whether to use cron intervals syntax.</p>
+        <p>Example: when <code>useCronIntervals=&#123;true&#125;</code>, a cron expression like &quot;<b>0 8 * * 1,3,5</b>&quot; (<i>&quot;At 08:00 AM, only on Monday, Wednesday, and Friday&quot;</i>)
+          would be changed to &quot;<b>0 8 * * 1-5/2</b>&quot; (<i>&quot;At 08:00 AM, every 2 days of the week, Monday through Friday&quot;</i>)</p>
+      </div>
+
+      <p>
+        Use cron intervals:
+        <Switch
+          checked={useCronIntervals}
+          onChange={event => {
+            setUseCronIntervals(event.target.checked)
+          }}
+        />
+      </p>
+      <p>Default value: {defaultValue}</p>
+      <p>Value: {value}</p>
+
+      <Cron
+        leadingZero
+        value={value}
+        setValue={setValue}
+        clearButtonAction="empty"
+        clockFormat="12-hour-clock"
+        useCronIntervals={useCronIntervals}
+      />
+
+      <div>
+        <InfoIcon style={{ marginRight: 5 }} />
+        <span style={{ fontSize: 12 }}>
+          If not set, the prop &quot;useCronIntervals&quot; is true
         </span>
       </div>
     </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,6 +77,18 @@ export interface CronProps {
   periodsToDisplay?: PeriodType[]
 
   /**
+   * Define which fields can select multiple values.
+   *
+   * Example: If you don't want to allow multiple hours or minutes to be selected,
+   * you can define allowMultipleSelectFor={['months', 'month-days', 'week-days']}.
+   * This way only months, month days and week days select components will be allowed
+   * to have multiple values in the cron expression.
+   *
+   * Default: ['months', 'month-days', 'week-days', 'hours', 'minutes']
+   */
+  allowMultipleSelectFor?: Omit<CronType, 'period'>[]
+
+  /**
    * Disable the cron component.
    *
    * Default: false
@@ -243,9 +255,10 @@ export interface FieldProps {
   readOnly: boolean
   useCronIntervals: boolean
   period: PeriodType
+  multiple: boolean
 }
 export interface PeriodProps
-  extends Omit<FieldProps, 'value' | 'setValue' | 'period' | 'useCronIntervals'> {
+  extends Omit<FieldProps, 'value' | 'setValue' | 'period' | 'useCronIntervals' | 'multiple'> {
   value: PeriodType
   setValue: SetValuePeriod
   shortcuts: Shortcuts

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,19 @@ export interface CronProps {
   defaultPeriod?: PeriodType
 
   /**
+   * Define the options of periods that will be displayed.
+   *
+   * Example: If you only want the option to generate cron expressions to
+   * represent a time in the day you can define periodsToDisplay={['day']}.
+   * The other options won't be available in the period select component.
+   *
+   * Default: ['year', 'month', 'week', 'day', 'hour', 'minute', 'reboot']
+   *
+   * OBS: 'reboot' option will apply only when '@reboot' is listed in shortcuts list.
+   */
+  periodsToDisplay?: PeriodType[]
+
+  /**
    * Disable the cron component.
    *
    * Default: false
@@ -236,6 +249,7 @@ export interface PeriodProps
   value: PeriodType
   setValue: SetValuePeriod
   shortcuts: Shortcuts
+  periodsToDisplay?: PeriodType[]
 }
 export interface MonthsProps extends FieldProps {
   humanizeLabels: boolean


### PR DESCRIPTION
<!--
Thank you for your contribution! 😄
-->

### 🤔 This is a ...

- [x] New feature
- [x] Bug fix
- [x] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] README update
- [ ] Other (about what?)

### 🔗 Related issue link

Don't have one.

### 💡 Background and solution

<!--
- Describe the problem and the scenario
- Describe the solution
- Describe the final API implementation
-->

Some contexts require to restrict the options of periods to build the cron expression (for instance, the `year`or `minute` period might not be wanted in some contexts).

Another option that might be required in some contexts is to not allow multiple values in the cron expression for a given field (hours, minutes, week days, etc). The current implementation always allow to select multiple values for all fields, which might be confusing and/or not wanted in some contexts.

So this PR includes:
- proposal to add `periodsToDisplay` optional configuration field to explicitly define which periods to display in the dropdown;
- proposal to add `allowMultipleSelectFor` optional configuration field to explicitly define which fields are allowed to accept multiple values in the cron expression;
- A more detailed example in storybook for previously added field `useCronIntervals`;
- Remove passing `grid` attribute to Material UI Select component to prevent noisy warning on console (see image below).

<img width="772" alt="Screenshot 2025-06-17 at 18 25 35" src="https://github.com/user-attachments/assets/0e4db85d-c6d5-4c69-a928-5f27e1da6563" />

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Demo in storybook is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] README API section is updated or not needed
